### PR TITLE
Fix #15 - relative paths without __dirname

### DIFF
--- a/bot/apis/database-crud.js
+++ b/bot/apis/database-crud.js
@@ -1,5 +1,5 @@
-const databaseHelper = require(__dirname + "/../utils/database-helper.js");
-const Logger = require(__dirname + "/../utils/logger.js");
+const databaseHelper = require("../utils/database-helper.js");
+const Logger = require("../utils/logger.js");
 
 /**
  * Returns whether the given associative array is empty

--- a/bot/classes/repository.js
+++ b/bot/classes/repository.js
@@ -32,10 +32,10 @@ class Repository extends RepositoryModel {
     }
 
     loadPluginsFromDisk() {
-        let pluginsPath = __dirname + "/../repositories/" + this._folderName + "/plugins";
+        let pluginsPath = "../repositories/" + this._folderName + "/plugins";
 
         if (fs.existsSync(pluginsPath)) {
-            fs.readdirSync(__dirname + "/../repositories/" + this._folderName + "/plugins").forEach(file => {
+            fs.readdirSync("../repositories/" + this._folderName + "/plugins").forEach(file => {
                 Logger.log("Building Plugin from folder **" + file + "**", "debug");
                 let plugin = new Plugin(pluginsPath + "/" + file);
                 this._pluginIds.push(plugin.id);
@@ -45,10 +45,10 @@ class Repository extends RepositoryModel {
     }
 
     loadPagesFromDisk() {
-        let pagesPath = __dirname + "/../repositories/" + this._folderName + "/pages";
+        let pagesPath = "../repositories/" + this._folderName + "/pages";
 
         if (fs.existsSync(pagesPath)) {
-            fs.readdirSync(__dirname + "/../repositories/" + this._folderName + "/pages").forEach(file => {
+            fs.readdirSync("../repositories/" + this._folderName + "/pages").forEach(file => {
                 Logger.log("Serving web folder **" + file + "**");
                 webServer.serveRepositoryFolder(file, this._folderName);
                 
@@ -78,7 +78,7 @@ class Repository extends RepositoryModel {
         Logger.log("Cloning **" + url + "**...");
         return new Promise((resolve, reject) => {
             let folderName = Repository._generateFolderName(url);
-            Git.Clone(url, __dirname + "/../repositories/" + folderName, {
+            Git.Clone(url, "../repositories/" + folderName, {
                 checkoutBranch: "master"
             }).then((repo) => {
                 db.insert("Repositories", {
@@ -118,7 +118,7 @@ class Repository extends RepositoryModel {
         return new Promise((resolve, reject) => {
             let repo;
             // Source: https://stackoverflow.com/questions/20955393/nodegit-libgit2-for-node-js-how-to-push-and-pull
-            Git.Repository.open(__dirname + "/../repositories/" + this._folderName)
+            Git.Repository.open("../repositories/" + this._folderName)
                 .then((repository) => {
                     repo = repository;
                     return repository.fetch("origin");
@@ -203,7 +203,7 @@ class Repository extends RepositoryModel {
      * Delete the folder
      */
     _deleteFolder() {
-        fileHelper.deleteFolder(__dirname + "/../repositories/" + this._folderName);
+        fileHelper.deleteFolder("../repositories/" + this._folderName);
     }
 
     static registerActions() {

--- a/bot/classes/repository.js
+++ b/bot/classes/repository.js
@@ -32,10 +32,10 @@ class Repository extends RepositoryModel {
     }
 
     loadPluginsFromDisk() {
-        let pluginsPath = "../repositories/" + this._folderName + "/plugins";
+        let pluginsPath = __dirname + "/../repositories/" + this._folderName + "/plugins";
 
         if (fs.existsSync(pluginsPath)) {
-            fs.readdirSync("../repositories/" + this._folderName + "/plugins").forEach(file => {
+            fs.readdirSync(__dirname + "/../repositories/" + this._folderName + "/plugins").forEach(file => {
                 Logger.log("Building Plugin from folder **" + file + "**", "debug");
                 let plugin = new Plugin(pluginsPath + "/" + file);
                 this._pluginIds.push(plugin.id);
@@ -45,10 +45,10 @@ class Repository extends RepositoryModel {
     }
 
     loadPagesFromDisk() {
-        let pagesPath = "../repositories/" + this._folderName + "/pages";
+        let pagesPath = __dirname + "/../repositories/" + this._folderName + "/pages";
 
         if (fs.existsSync(pagesPath)) {
-            fs.readdirSync("../repositories/" + this._folderName + "/pages").forEach(file => {
+            fs.readdirSync(__dirname + "/../repositories/" + this._folderName + "/pages").forEach(file => {
                 Logger.log("Serving web folder **" + file + "**");
                 webServer.serveRepositoryFolder(file, this._folderName);
                 
@@ -78,7 +78,7 @@ class Repository extends RepositoryModel {
         Logger.log("Cloning **" + url + "**...");
         return new Promise((resolve, reject) => {
             let folderName = Repository._generateFolderName(url);
-            Git.Clone(url, "../repositories/" + folderName, {
+            Git.Clone(url, __dirname + "/../repositories/" + folderName, {
                 checkoutBranch: "master"
             }).then((repo) => {
                 db.insert("Repositories", {
@@ -118,7 +118,7 @@ class Repository extends RepositoryModel {
         return new Promise((resolve, reject) => {
             let repo;
             // Source: https://stackoverflow.com/questions/20955393/nodegit-libgit2-for-node-js-how-to-push-and-pull
-            Git.Repository.open("../repositories/" + this._folderName)
+            Git.Repository.open(__dirname + "/../repositories/" + this._folderName)
                 .then((repository) => {
                     repo = repository;
                     return repository.fetch("origin");
@@ -203,7 +203,7 @@ class Repository extends RepositoryModel {
      * Delete the folder
      */
     _deleteFolder() {
-        fileHelper.deleteFolder("../repositories/" + this._folderName);
+        fileHelper.deleteFolder(__dirname + "/../repositories/" + this._folderName);
     }
 
     static registerActions() {

--- a/bot/utils/database-helper.js
+++ b/bot/utils/database-helper.js
@@ -1,8 +1,8 @@
 const sqlite = require("sqlite3");
 const fs = require("fs");
-const config = require(__dirname + "/../config/config.json");
+const config = require("../config/config.json");
 
-const Logger = require(__dirname + "/../utils/logger.js");
+const Logger = require("../utils/logger.js");
 
 let database;
 

--- a/bot/webserver.js
+++ b/bot/webserver.js
@@ -15,8 +15,8 @@ const credentials = {
 };
 
 module.exports.serveDashboard = () => {
-    app.use("/dashboard", express.static("../dashboard"));
-    app.use("/models", express.static("../models"));
+    app.use("/dashboard", express.static(__dirname + "/../dashboard"));
+    app.use("/models", express.static(__dirname + "/../models"));
     app.get("/", (req, res) => {
         res.redirect("/dashboard");
     });
@@ -30,7 +30,7 @@ module.exports.serveRepositoryFolder = (folderName, repositoryFolderName) => {
         Logger.log("Could not serve folder **" + folderName + "** because it is a reserved page name.", "warn");
         return;
     } else {
-        app.use("/" + folderName, express.static("./repositories/" + repositoryFolderName + "/pages/" + folderName));
+        app.use("/" + folderName, express.static(__dirname + "/repositories/" + repositoryFolderName + "/pages/" + folderName));
     }
 };
 

--- a/bot/webserver.js
+++ b/bot/webserver.js
@@ -3,8 +3,8 @@ const app = express();
 
 const http = require("http");
 const https = require("https");
-const config = require(__dirname + "/config/config.json");
-const Logger = require(__dirname + "/utils/logger.js");
+const config = require("./config/config.json");
+const Logger = require("./utils/logger.js");
 const webAPI = require("./apis/web-api.js");
 
 const appConfig = require("./config/app-config.json");

--- a/bot/webserver.js
+++ b/bot/webserver.js
@@ -15,8 +15,8 @@ const credentials = {
 };
 
 module.exports.serveDashboard = () => {
-    app.use("/dashboard", express.static(__dirname + "/../dashboard"));
-    app.use("/models", express.static(__dirname + "/../models"));
+    app.use("/dashboard", express.static("../dashboard"));
+    app.use("/models", express.static("../models"));
     app.get("/", (req, res) => {
         res.redirect("/dashboard");
     });
@@ -30,7 +30,7 @@ module.exports.serveRepositoryFolder = (folderName, repositoryFolderName) => {
         Logger.log("Could not serve folder **" + folderName + "** because it is a reserved page name.", "warn");
         return;
     } else {
-        app.use("/" + folderName, express.static(__dirname + "/repositories/" + repositoryFolderName + "/pages/" + folderName));
+        app.use("/" + folderName, express.static("./repositories/" + repositoryFolderName + "/pages/" + folderName));
     }
 };
 


### PR DESCRIPTION
Fix #15 

`require` never should use __dirname, so it was removed there.

Not sure about the other uses, need feedback on these proposals:

- Always work off of the working directory as the base. Don't assume where things are based on what we expect the cwd to be.
- As such, would it make more sense to have the `dashboard` and `models` folders based off of __dirname, while `repositories` is in the cwd?