### PR TITLE
Use server acronym when no icon specified

### DIFF
--- a/dashboard/src/models/guild.js
+++ b/dashboard/src/models/guild.js
@@ -4,17 +4,18 @@ window.Discotron.Guild = class extends window.Discotron.GuildModel {
      * @param {string} discordId Id of the guild
      * @param {string} name Name of the guild
      * @param {string} iconURL Icon of the guild
+     * @param {string} acronym Server acronym, used in case no icon is defined
      * @param {string} commandPrefix Command prefix
      * @param {array} allowedChannelIds Array of channel ids on which the bot is allowed
      * @param {array} enabledPluginIds Array of plugin ids that are enabled
      * @param {array} admins Array of UserRole who have admin priviledge on the bot
      * @param {object} permissions Associative object binding pluginsIds to userRole array
      */
-    constructor(discordId, name, iconURL, commandPrefix, allowedChannelIds, enabledPlugins, admins, permissions) {
+    constructor(discordId, name, iconURL, acronym, commandPrefix, allowedChannelIds, enabledPlugins, admins, permissions) {
         super(discordId, commandPrefix, allowedChannelIds, enabledPlugins, admins, permissions);
 
         this._name = name;
-        this._iconURL = (iconURL === null) ? "/dashboard/images/outage.png" : iconURL;
+        this._iconURL = (iconURL === null) ? Discotron.utils.generateAcronymIcon(acronym, "#fff", "#4e4e4e") : iconURL;
 
         // Load as needed
         this._members = []; // ids
@@ -125,7 +126,7 @@ window.Discotron.Guild = class extends window.Discotron.GuildModel {
                             permissions[pluginId] = new Discotron.Permission(this.discordId, pluginId, usersRoles);
                         }
 
-                        let guild = new Discotron.Guild(obj.id, obj.name, obj.image, obj.prefix, new Set(obj.allowedChannelIds), new Set(obj.enabledPluginIds), new Set(admins), permissions);
+                        let guild = new Discotron.Guild(obj.id, obj.name, obj.image, obj.nameAcronym, obj.prefix, new Set(obj.allowedChannelIds), new Set(obj.enabledPluginIds), new Set(admins), permissions);
                     }
                     resolve(Discotron.Guild._guilds);
                 });

--- a/dashboard/src/utils.js
+++ b/dashboard/src/utils.js
@@ -30,5 +30,34 @@ window.Discotron.utils = {
                     callback();
                 }
             });
+    },
+    generateAcronymIcon: (acronym, fgColor, bgColor) => {
+        const size = 88;
+        const padding = 4;
+        const font = "sans-serif";
+
+        const canvas = document.createElement("canvas");
+        canvas.width = size;
+        canvas.height = size;
+
+        // Fill canvas background
+        const ctx = canvas.getContext("2d");
+        ctx.fillStyle = bgColor;
+        ctx.fillRect(0, 0, size, size);
+
+        // Add text, fit to size
+        let fontsize = 30;
+        do {
+            ctx.font = `${fontsize}px ${font}`;
+            fontsize--;
+        } while (ctx.measureText(acronym).width > size - padding);
+        ctx.fillStyle = fgColor;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(acronym, size/2, size/2);
+
+        // Render to data url
+        const img = canvas.toDataURL('image/png');
+        return img;
     }
 };


### PR DESCRIPTION
Closes #17 

Uses canvas to generate an image which is used instead of the iconURL.
Long acronym will scale to fit: 
![image](https://user-images.githubusercontent.com/5117197/66847240-58b44f00-ef73-11e9-9582-65ed3a275a0d.png)

Maybe the foreground and background color should not be hardcoded parameter values, but instead be retrieved from the respective css variables. But the model shouldn't know about rendering anyway, so it might make more sense to move this check over to each view? Just don't know how it should be de-duplicated then...