### PR TITLE
Move user configs outside of regular file structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,9 +93,5 @@ typings/
 !.vscode/launch.json
 !.vscode/extensions.json
 
-token.txt
-app-config.json
-discotron.db
-dashboard/config/config.js
-repositories/
-bot/.installed
+instance/*
+!instance/README.md

--- a/bot/classes/login.js
+++ b/bot/classes/login.js
@@ -8,7 +8,7 @@ const request = require("request");
 const Logger = require("../utils/logger.js");
 const db = require("../apis/database-crud.js");
 
-const appConfig = require(global.discotron.configPath + "/bot.json");
+const appConfig = require(global.discotronConfigPath + "/bot.json");
 
 let users = {};
 let firstLaunch = false;

--- a/bot/classes/login.js
+++ b/bot/classes/login.js
@@ -8,7 +8,7 @@ const request = require("request");
 const Logger = require("../utils/logger.js");
 const db = require("../apis/database-crud.js");
 
-const appConfig = require("../config/app-config.json");
+const appConfig = require(global.discotron.configPath + "/bot.json");
 
 let users = {};
 let firstLaunch = false;

--- a/bot/config/config.json
+++ b/bot/config/config.json
@@ -1,7 +1,7 @@
 {
     "database": {
         "templatePath": "./database/discotron-template.db",
-        "savePath": "./database/discotron.db"
+        "saveName": "discotron.db"
     },
     "webServer": {
         "port": 47131

--- a/bot/index.js
+++ b/bot/index.js
@@ -10,7 +10,7 @@ handleArgs(parseArgs(process.argv));
 let appConfig;
 loadConfig();
 
-global.discotron = {configPath: configPath};
+global.discotronConfigPath = configPath;
 
 const databaseHelper = require("./utils/database-helper.js");
 // Database
@@ -27,8 +27,6 @@ const discordClient = new DiscordJS.Client();
 
 global.discotron = discotron;
 global.discordClient = discordClient;
-
-discotron.configPath = configPath;
 
 discotron.loadOwners();
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -2,9 +2,15 @@ const Logger = require("./utils/logger.js");
 Logger.setSeverity("info");
 
 const DiscordJS = require("discord.js");
+const parseArgs = require("minimist");
+
+let configPath = __dirname + "/../instance";
+handleArgs(parseArgs(process.argv));
 
 let appConfig;
 loadConfig();
+
+global.discotron = {configPath: configPath};
 
 const databaseHelper = require("./utils/database-helper.js");
 // Database
@@ -21,6 +27,8 @@ const discordClient = new DiscordJS.Client();
 
 global.discotron = discotron;
 global.discordClient = discordClient;
+
+discotron.configPath = configPath;
 
 discotron.loadOwners();
 
@@ -92,25 +100,40 @@ function registerEvents() {
 }
 
 /**
+ * Handle command-line arguments passed to the executable.
+ * @param {object} args Parsed arguments as an object. 
+ */
+function handleArgs(args) {
+    // Path where all configs are stored
+    const cfgPath = args["config-path"] || args.c;
+    if (cfgPath) {
+        configPath = cfgPath;
+        if (configPath[configPath.length-1] === "/") {
+            configPath = configPath.substr(0, configPath.length - 1);
+        }
+    }
+}
+
+/**
  * Attempts to load the config from disk, checks for missing files
  */
 function loadConfig() {
     try {
-        appConfig = require("./config/app-config.json");
+        appConfig = require(configPath + "/bot.json");
         if (typeof appConfig.token === "undefined" || appConfig.token === "") {
-            Logger.log("Missing **token** in **app-config.json**.", "err");
+            Logger.log("Missing **token** in **bot.json**.", "err");
             process.exit();
         }
         if (typeof appConfig.applicationId === "undefined" || appConfig.applicationId === "") {
-            Logger.log("Missing **applicationId** in **app-config.json**.", "err");
+            Logger.log("Missing **applicationId** in **bot.json**.", "err");
             process.exit();
         }
         if (typeof appConfig.oauth2Secret === "undefined" || appConfig.oauth2Secret === "") {
-            Logger.log("Missing **oauth2Secret** in **app-config.json**.", "err");
+            Logger.log("Missing **oauth2Secret** in **bot.json**.", "err");
             process.exit();
         }
         if (typeof appConfig.redirectURI === "undefined" || appConfig.redirectURI === "") {
-            Logger.log("Missing **redirectURI** in **app-config.json**.", "err");
+            Logger.log("Missing **redirectURI** in **bot.json**.", "err");
             process.exit();
         }
     } catch (err) {

--- a/bot/index.js
+++ b/bot/index.js
@@ -4,13 +4,11 @@ Logger.setSeverity("info");
 const DiscordJS = require("discord.js");
 const parseArgs = require("minimist");
 
-let configPath = __dirname + "/../instance";
+global.discotronConfigPath = __dirname + "/../instance";
 handleArgs(parseArgs(process.argv));
 
 let appConfig;
 loadConfig();
-
-global.discotronConfigPath = configPath;
 
 const databaseHelper = require("./utils/database-helper.js");
 // Database
@@ -105,9 +103,9 @@ function handleArgs(args) {
     // Path where all configs are stored
     const cfgPath = args["config-path"] || args.c;
     if (cfgPath) {
-        configPath = cfgPath;
-        if (configPath[configPath.length-1] === "/") {
-            configPath = configPath.substr(0, configPath.length - 1);
+        global.discotronConfigPath = cfgPath;
+        if (cfgPath[cfgPath.length - 1] === "/") {
+            global.discotronConfigPath = cfgPath.substr(0, cfgPath.length - 1);
         }
     }
 }
@@ -117,7 +115,7 @@ function handleArgs(args) {
  */
 function loadConfig() {
     try {
-        appConfig = require(configPath + "/bot.json");
+        appConfig = require(global.discotronConfigPath + "/bot.json");
         if (typeof appConfig.token === "undefined" || appConfig.token === "") {
             Logger.log("Missing **token** in **bot.json**.", "err");
             process.exit();

--- a/bot/install.sh
+++ b/bot/install.sh
@@ -9,14 +9,14 @@ if [[ -f "$FOOTPRINT" ]]; then
 fi
 
 #Check if some files are already existing
-APPCFG=./config/app-config.json
+APPCFG=../instance/bot.json
 if [[ -f "$APPCFG" ]]; then
     echo "File $APPCFG already exists, but installation was not run yet!"
     echo "Please delete the file to re-run the installation."
     echo ""
     exit
 fi
-DASHCFG=../dashboard/config/config.js
+DASHCFG=../instance/dashboard.js
 if [[ -f "$DASHCFG" ]]; then
     echo "File $DASHCFG already exists, but installation was not run yet!"
     echo "Please delete the file to re-run the installation."
@@ -25,6 +25,8 @@ if [[ -f "$DASHCFG" ]]; then
 fi
 
 echo "=== Discotron Install Script ==="
+echo ""
+echo "This script will create a default configuration in the 'instance' folder to get the bot up and running."
 echo ""
 echo "If you haven't already, visit https://discordapp.com/developers/applications/"
 echo "and create a new application for Discotron. The following information is retrieved"

--- a/bot/install.sh
+++ b/bot/install.sh
@@ -52,7 +52,7 @@ while : ; do
     # Either empty, or matching a domain-like regex
     if [[ -z "$domain" ]]; then
         # fallback value: localhost
-        domain=http://localhost
+        domain=http://localhost:47131
         break
     else
         # correctly specified
@@ -64,6 +64,7 @@ done
 if [[ ! "$domain" =~ ^.+/$ ]]; then
     domain="$domain/"
 fi
+# todo: this must always include the port of our web server, else redirection will cause oauth errors!
 domain="${domain}dashboard/login.html"
 
 while : ; do

--- a/bot/install.sh
+++ b/bot/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # We leave behind a file which remembers if we ran the install script
-FOOTPRINT=./.installed
+FOOTPRINT=../instance/.installed
 if [[ -f "$FOOTPRINT" ]]; then
     echo "Discotron install script already finished, skipping."
     echo ""

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -706,9 +706,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
       "version": "2.5.0",
@@ -733,6 +733,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "ms": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "discord.js": "^11.5.1",
     "express": "^4.17.1",
+    "minimist": "^1.2.0",
     "nodegit": "^0.25.1",
     "sqlite3": "^4.1.0",
     "uuid": "^3.3.3"

--- a/bot/utils/database-helper.js
+++ b/bot/utils/database-helper.js
@@ -1,7 +1,7 @@
 const sqlite = require("sqlite3");
 const fs = require("fs");
 const config = require("../config/config.json");
-let dbPath = global.discotronConfigPath + "/" + config.database.saveName;
+const databasePath = global.discotronConfigPath + "/" + config.database.saveName;
 
 const Logger = require("../utils/logger.js");
 
@@ -11,7 +11,7 @@ let database;
  * @returns {boolean} True if a database file already exists
  */
 module.exports.databaseExists = () => {
-    return fs.existsSync(dbPath);
+    return fs.existsSync(databasePath);
 };
 
 /**
@@ -19,7 +19,7 @@ module.exports.databaseExists = () => {
  * TODO: Use migrations! This is going to hit us in the face at some point
  */
 module.exports.createDatabase = () => {
-    fs.copyFileSync(config.database.templatePath, dbPath);
+    fs.copyFileSync(config.database.templatePath, databasePath);
 };
 
 /**
@@ -27,7 +27,7 @@ module.exports.createDatabase = () => {
  * I'm not sure why this exists
  */
 module.exports.deleteDatabase = () => {
-    fs.unlink(dbPath, (err) => {
+    fs.unlink(databasePath, (err) => {
         if (err) {
             Logger.log("Could not delete database", "error");
         }
@@ -38,7 +38,7 @@ module.exports.deleteDatabase = () => {
  * Open sqlite database from its file
  */
 module.exports.openDatabase = () => {
-    database = new sqlite.Database(dbPath, sqlite.OPEN_READWRITE, (err) => {
+    database = new sqlite.Database(databasePath, sqlite.OPEN_READWRITE, (err) => {
         if (err) {
             Logger.log("Could not open database", "error");
             Logger.log(err, "err");

--- a/bot/utils/database-helper.js
+++ b/bot/utils/database-helper.js
@@ -1,6 +1,7 @@
 const sqlite = require("sqlite3");
 const fs = require("fs");
 const config = require("../config/config.json");
+let dbPath = global.discotron.configPath + "/" + config.database.saveName;
 
 const Logger = require("../utils/logger.js");
 
@@ -10,7 +11,7 @@ let database;
  * @returns {boolean} True if a database file already exists
  */
 module.exports.databaseExists = () => {
-    return fs.existsSync(config.database.savePath);
+    return fs.existsSync(dbPath);
 };
 
 /**
@@ -18,7 +19,7 @@ module.exports.databaseExists = () => {
  * TODO: Use migrations! This is going to hit us in the face at some point
  */
 module.exports.createDatabase = () => {
-    fs.copyFileSync(config.database.templatePath, config.database.savePath);
+    fs.copyFileSync(config.database.templatePath, dbPath);
 };
 
 /**
@@ -26,7 +27,7 @@ module.exports.createDatabase = () => {
  * I'm not sure why this exists
  */
 module.exports.deleteDatabase = () => {
-    fs.unlink(config.database.savePath, (err) => {
+    fs.unlink(dbPath, (err) => {
         if (err) {
             Logger.log("Could not delete database", "error");
         }
@@ -37,7 +38,7 @@ module.exports.deleteDatabase = () => {
  * Open sqlite database from its file
  */
 module.exports.openDatabase = () => {
-    database = new sqlite.Database(config.database.savePath, sqlite.OPEN_READWRITE, (err) => {
+    database = new sqlite.Database(dbPath, sqlite.OPEN_READWRITE, (err) => {
         if (err) {
             Logger.log("Could not open database", "error");
             Logger.log(err, "err");

--- a/bot/utils/database-helper.js
+++ b/bot/utils/database-helper.js
@@ -1,7 +1,7 @@
 const sqlite = require("sqlite3");
 const fs = require("fs");
 const config = require("../config/config.json");
-let dbPath = global.discotron.configPath + "/" + config.database.saveName;
+let dbPath = global.discotronConfigPath + "/" + config.database.saveName;
 
 const Logger = require("../utils/logger.js");
 

--- a/bot/webserver.js
+++ b/bot/webserver.js
@@ -8,7 +8,7 @@ const config = require("./config/config.json");
 const Logger = require("./utils/logger.js");
 const webAPI = require("./apis/web-api.js");
 
-const appConfig = require("./config/app-config.json");
+const appConfig = require(global.discotron.configPath + "/bot.json");
 
 /**
  * Serve the dashboard, login and models folders
@@ -16,6 +16,7 @@ const appConfig = require("./config/app-config.json");
 module.exports.serveDashboard = () => {
     app.use("/dashboard", express.static(__dirname + "/../dashboard"));
     app.use("/models", express.static(__dirname + "/../models"));
+    app.use("/dashboard/config/dashboard.js", express.static(global.discotron.configPath + "/dashboard.js"));
     app.get("/", (req, res) => {
         res.redirect("/dashboard");
     });
@@ -52,7 +53,7 @@ if (typeof appConfig.privateKey === "undefined" || typeof appConfig.certificate 
     Logger.log("**Dashboard and web pages are served without https!**", "warn");
     Logger.log("A hacker could **easily** access your computer as well as compromising all Discord guilds the bot is in.", "warn");
     Logger.log("To prevent that, secure your server using a service like **letsencrypt**.", "warn");
-    Logger.log("You can then add **privateKeyPath** and **certificatePath** in __bot/config/app-config.json__ to fix the issue.", "warn");
+    Logger.log("You can then add **privateKeyPath** and **certificatePath** in __bot.json__ to fix the issue.", "warn");
     Logger.log("This warning will go away once the server is secured.", "warn");
 
 

--- a/bot/webserver.js
+++ b/bot/webserver.js
@@ -8,7 +8,7 @@ const config = require("./config/config.json");
 const Logger = require("./utils/logger.js");
 const webAPI = require("./apis/web-api.js");
 
-const appConfig = require(global.discotron.configPath + "/bot.json");
+const appConfig = require(global.discotronConfigPath + "/bot.json");
 
 /**
  * Serve the dashboard, login and models folders
@@ -16,7 +16,7 @@ const appConfig = require(global.discotron.configPath + "/bot.json");
 module.exports.serveDashboard = () => {
     app.use("/dashboard", express.static(__dirname + "/../dashboard"));
     app.use("/models", express.static(__dirname + "/../models"));
-    app.use("/dashboard/config/dashboard.js", express.static(global.discotron.configPath + "/dashboard.js"));
+    app.use("/dashboard/config/dashboard.js", express.static(global.discotronConfigPath + "/dashboard.js"));
     app.get("/", (req, res) => {
         res.redirect("/dashboard");
     });

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -50,7 +50,7 @@
     </script>
 
     <!-- Config -->
-    <script src="/dashboard/config/config.js"></script>
+    <script src="/dashboard/config/dashboard.js"></script>
 
     <!-- Utils-->
     <script src="/dashboard/src/utils.js"></script>

--- a/dashboard/login.html
+++ b/dashboard/login.html
@@ -65,7 +65,7 @@
     <script src="/dashboard/src/utils.js"></script>
 
     <!-- Config -->
-    <script src="/dashboard/config/config.js"></script>
+    <script src="/dashboard/config/dashboard.js"></script>
 
     <!-- API -->
     <script src="/dashboard/src/web-api.js"></script>

--- a/dashboard/src/controllers/login-controller.js
+++ b/dashboard/src/controllers/login-controller.js
@@ -40,7 +40,7 @@ window.Discotron.LoginController = class /* does not extends Controller because 
 
             document.querySelector(".widget-buttons").style.display = "none";
             document.querySelector("#login-error").style.display = "block";
-            document.querySelector("#login-error").innerHTML = "Could not load <b>dashboard/config/config.js</b>";
+            document.querySelector("#login-error").innerHTML = "Could not load <b>dashboard/config/dashboard.js</b>";
             return;
         }
 

--- a/dashboard/src/controllers/login-controller.js
+++ b/dashboard/src/controllers/login-controller.js
@@ -40,7 +40,7 @@ window.Discotron.LoginController = class /* does not extends Controller because 
 
             document.querySelector(".widget-buttons").style.display = "none";
             document.querySelector("#login-error").style.display = "block";
-            document.querySelector("#login-error").innerHTML = "Could not load <b>dashboard/config/dashboard.js</b>";
+            document.querySelector("#login-error").innerHTML = "Could not load <b>dashboard.js</b>";
             return;
         }
 

--- a/instance/README.md
+++ b/instance/README.md
@@ -1,0 +1,4 @@
+## This is the location for Discotron's default instance.
+When running Discotron for the first time, this directory is used to store all kinds of configuration files.
+
+Read more about the configs and how to change their location on [the wiki](https://github.com/forwards-long-jump/discotron/wiki).


### PR DESCRIPTION
- Create a default user instance (located in the root `instance` folder)
- Update install.sh script accordingly
- Update scripts referencing these configs

To keep consistent, the `config.json` is not moved. In the end, most of these things should be moved into the database and configured when first launching the bot itself (as opposed to an external installer script).

TODO: Update docs (wiki) to include command-line argument list.