### PR TITLE
Disallow plugins with same id and improve error handling

### DIFF
--- a/dashboard/src/controllers/repository-list-controller.js
+++ b/dashboard/src/controllers/repository-list-controller.js
@@ -144,10 +144,10 @@ window.discotron.RepositoryListController = class extends window.discotron.Contr
             document.getElementById("add-repository").disabled = true;
             discotron.WebAPI.queryBot("discotron-dashboard", "add-repository", {
                 url: repoUrl
-            }).then((data) => {
+            }).then((err) => {
                 document.getElementById("add-repository").disabled = false;
-                if (!data) {
-                    document.getElementById("repository-error").textContent = "Could not load repository";
+                if (err) {
+                    document.getElementById("repository-error").textContent = "Could not load repository: " + err;
                     document.getElementById("repository-url").focus();
                     document.getElementById("repository-url").select();
                 } else {


### PR DESCRIPTION
Fix #25 

- Folder name of repository now does not use hash anymore (id must be unique)
- Plugin with same id may not be cloned
- Show friendly error message to user (feedback regarding the error handling code is appreciated! We don't have a good design for this)